### PR TITLE
Add reverse order support to EventsourceLayer.currentEventsById

### DIFF
--- a/fdb-record-es-tests/src/test/scala/com/goodcover/fdb/record/EventsourceLayerSpec.scala
+++ b/fdb-record-es-tests/src/test/scala/com/goodcover/fdb/record/EventsourceLayerSpec.scala
@@ -33,6 +33,24 @@ object EventsourceLayerSpec extends ZIOSpecDefault {
           service.currentEventsById(persistenceId, 0L, Long.MaxValue).runCollect
       } yield assertTrue(consumer.size == elements)
     },
+    test("reverse reads newest events first and honors max") {
+      val elements = 10
+      for {
+        service      <- ZIO.service[EventsourceLayer]
+        persistenceId = "pid-reverse"
+        _            <- ZStream
+                          .range(0, elements)
+                          .mapZIO(i => simpleAppend(persistenceId, i.toLong, "tagr" :: Nil).as(i.toLong))
+                          .runCollect
+        newestThree  <- service.currentEventsById(persistenceId, reverse = true, max = 3).runCollect
+        allReversed  <- service.currentEventsById(persistenceId, reverse = true).runCollect
+        forward      <- service.currentEventsById(persistenceId).runCollect
+      } yield assertTrue(
+        newestThree.map(_.sequenceNr).toList == List(9L, 8L, 7L),
+        allReversed.map(_.sequenceNr).toList == (0L until elements.toLong).reverse.toList,
+        forward.map(_.sequenceNr).toList == (0L until elements.toLong).toList,
+      )
+    },
     test("insert elements") {
       val totalElementsPerId     = 20
       val differentPersistentIds = 500

--- a/fdb-record-es/src/main/scala/com/goodcover/fdb/record/es/EventsourceLayer.scala
+++ b/fdb-record-es/src/main/scala/com/goodcover/fdb/record/es/EventsourceLayer.scala
@@ -146,7 +146,8 @@ class EventsourceLayer(recordDb: FdbRecordDatabase, cfg: RecordConfig, metaRef: 
     persistenceId: String,
     fromSequenceNr: Long = 0L,
     toSequenceNr: Long = Long.MaxValue,
-    max: Int = Int.MaxValue
+    max: Int = Int.MaxValue,
+    reverse: Boolean = false
   )(implicit trace: Trace): ZStream[Any, Throwable, PersistentRepr] =
     recordDb.streamAsyncContinuation { continue =>
       ZStream.unwrap {
@@ -155,12 +156,20 @@ class EventsourceLayer(recordDb: FdbRecordDatabase, cfg: RecordConfig, metaRef: 
           rc      <- ZIO.service[FdbRecordContext]
           evStore <- mkStore(rc)
           query   <- ZIO.succeed {
-                       RecordQuery
+                       val builder = RecordQuery
                          .newBuilder()
                          .setRecordType("PersistentRepr")
                          .setFilter(buildEventsRangeQuery(persistenceId, fromSequenceNr, toSequenceNr))
-                         .build()
 
+                       // Descending sequenceNr order plans as a reverse primary-key range scan (the primary key
+                       // is (recordType, persistenceId, sequenceNr) and persistenceId is an equality filter), so
+                       // newest-N reads with `max` are as cheap as oldest-N.
+                       val sorted  =
+                         if (reverse)
+                           builder.setSort(Key.Expressions.concatenateFields("persistenceId", "sequenceNr"), true)
+                         else builder
+
+                       sorted.build()
                      }
         } yield evStore
           .executeQuery(query, continue, ExecuteProperties.newBuilder().setReturnedRowLimit(max).build())


### PR DESCRIPTION
## Summary

Adds a `reverse: Boolean = false` parameter to `EventsourceLayer.currentEventsById`.

The `PersistentRepr` record's primary key is `(recordType, persistenceId, sequenceNr)` and `persistenceId` is always an equality filter here, so sorting by descending `sequenceNr` plans as a **reverse primary-key range scan** — a newest-N read with `max` costs the same as an oldest-N read, with no extra index.

Forward callers are unaffected: the sort is only applied when `reverse = true`, so existing query plans don't change.

## Motivation

Consumers that show the most recent journal activity (e.g. goodcover/core's TLL program journal panel) currently materialize the full event stream and take the tail, which degrades linearly with journal size. With this flag they can read exactly N newest events. It also pairs with `fromSequenceNr`/`toSequenceNr` for descending cursor pagination (`beforeSeqNr`-style paging).

## Testing

New `EventsourceLayerSpec` case appends 10 events and asserts newest-3 (`reverse = true, max = 3` → 9, 8, 7), full reverse ordering, and unchanged forward ordering. All 14 spec tests pass against a local FDB cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)