### PR TITLE
API improvements: owned executor, context properties, Lucene helpers, store primitives

### DIFF
--- a/fdb-core-tests/src/test/scala/com/goodcover/fdb/FoundationDbSpec.scala
+++ b/fdb-core-tests/src/test/scala/com/goodcover/fdb/FoundationDbSpec.scala
@@ -212,7 +212,7 @@ object FoundationDbSpec extends ZIOSpecDefault {
           }
       } yield assertTrue(result.nonEmpty && result.exists(_.nonEmpty))
     }
-  ) @@ TestAspect.withLiveClock)
+  ) @@ TestAspect.withLiveClock @@ TestAspect.timeout(2.minutes))
     .provideSome[FdbDatabase & FdbStream](
       FdbSpecLayers.suiteSubspaceLayer >+> TestKeySpace.live
     )

--- a/fdb-core/src/main/scala/com/goodcover/fdb/Fdb.scala
+++ b/fdb-core/src/main/scala/com/goodcover/fdb/Fdb.scala
@@ -685,34 +685,48 @@ object FdbStream {
  * Configuration for FoundationDB client connections.
  *
  * @param minConnections
- *   Minimum number of connections to maintain in the connection pool. Default: 1
+ *   Minimum number of connections to maintain in the connection pool. Default:
+ *   1
  * @param maxConnections
  *   Maximum number of connections allowed in the connection pool. Default: 50
  * @param apiVersion
- *   FoundationDB API version to use (e.g., 710, 720). This should match your FoundationDB server version. Default: 710
+ *   FoundationDB API version to use (e.g., 710, 720). This should match your
+ *   FoundationDB server version. Default: 710
  * @param clusterFile
- *   Path to the FoundationDB cluster file. If None, the default cluster file location will be used. Default: None
+ *   Path to the FoundationDB cluster file. If None, the default cluster file
+ *   location will be used. Default: None
  * @param searchClusterFile
  *   Whether to search for the cluster file in default locations. Default: false
  * @param _retryPolicy
- *   Retry policy for failed operations. Format: "e<milliseconds>" for exponential backoff (e.g., "e10" = exponential starting at 10ms). Default: "e10"
+ *   Retry policy for failed operations. Format: "e<milliseconds>" for
+ *   exponential backoff (e.g., "e10" = exponential starting at 10ms). Default:
+ *   "e10"
  * @param timeToLive
- *   Time to live for database connections before they are recycled. Default: 30 seconds
+ *   Time to live for database connections before they are recycled. Default: 30
+ *   seconds
  * @param performClassLoaderFixes
- *   Whether to perform classloader fixes for FoundationDB native library loading. This can help with classloader issues in some environments. Default: true
+ *   Whether to perform classloader fixes for FoundationDB native library
+ *   loading. This can help with classloader issues in some environments.
+ *   Default: true
  * @param warnOnUnclosed
- *   Whether to warn when database connections are not properly closed. Useful for debugging resource leaks. Default: false
+ *   Whether to warn when database connections are not properly closed. Useful
+ *   for debugging resource leaks. Default: false
  * @param setFdbCLibraryPath
- *   Explicitly set the path to the FoundationDB C library (libfdb_c). If None, the library will be loaded from the default location. Default: None
+ *   Explicitly set the path to the FoundationDB C library (libfdb_c). If None,
+ *   the library will be loaded from the default location. Default: None
  * @param getFdbCLibraryFromEnv
- *   Whether to get the FoundationDB C library path from environment variables. Default: true
+ *   Whether to get the FoundationDB C library path from environment variables.
+ *   Default: true
  * @param fdbExecutor
- *   Optional custom executor for FoundationDB operations. If None, the default executor will be used. Default: None
+ *   Optional custom executor for FoundationDB operations. If None, the default
+ *   executor will be used. Default: None
  * @param recordExecutor
- *   Optional custom executor for record-layer asynchronous tasks (everything downstream of FDBDatabaseFactory). If
- *   None, the record layer creates and owns a dedicated executor: virtual-thread-per-task on JDK 21+, otherwise a
- *   named daemon cached thread pool. This replaces the JDK common pool default, which is easily starved by blocking
- *   work (e.g. Lucene index I/O). Default: None
+ *   Optional custom executor for record-layer asynchronous tasks (everything
+ *   downstream of FDBDatabaseFactory). If None, the record layer creates and
+ *   owns a dedicated executor: virtual-thread-per-task on JDK 21+, otherwise a
+ *   named daemon cached thread pool. This replaces the JDK common pool default,
+ *   which is easily starved by blocking work (e.g. Lucene index I/O). Default:
+ *   None
  */
 case class FoundationDbConfig(
   minConnections: Int,

--- a/fdb-core/src/main/scala/com/goodcover/fdb/Fdb.scala
+++ b/fdb-core/src/main/scala/com/goodcover/fdb/Fdb.scala
@@ -708,6 +708,11 @@ object FdbStream {
  *   Whether to get the FoundationDB C library path from environment variables. Default: true
  * @param fdbExecutor
  *   Optional custom executor for FoundationDB operations. If None, the default executor will be used. Default: None
+ * @param recordExecutor
+ *   Optional custom executor for record-layer asynchronous tasks (everything downstream of FDBDatabaseFactory). If
+ *   None, the record layer creates and owns a dedicated executor: virtual-thread-per-task on JDK 21+, otherwise a
+ *   named daemon cached thread pool. This replaces the JDK common pool default, which is easily starved by blocking
+ *   work (e.g. Lucene index I/O). Default: None
  */
 case class FoundationDbConfig(
   minConnections: Int,
@@ -722,6 +727,7 @@ case class FoundationDbConfig(
   setFdbCLibraryPath: Option[String],
   getFdbCLibraryFromEnv: Boolean,
   fdbExecutor: Option[Executor],
+  recordExecutor: Option[Executor],
 ) {
   def withClusterFile(cf: Option[String]): FoundationDbConfig = copy(clusterFile = cf)
 
@@ -751,6 +757,7 @@ object FoundationDbConfig {
     setFdbCLibraryPath = None,
     getFdbCLibraryFromEnv = true,
     fdbExecutor = None,
+    recordExecutor = None,
   )
 
   final val MIN_CONNECTIONS            = "minconnections"

--- a/fdb-core/src/main/scala/com/goodcover/fdb/Fdb.scala
+++ b/fdb-core/src/main/scala/com/goodcover/fdb/Fdb.scala
@@ -723,10 +723,11 @@ object FdbStream {
  * @param recordExecutor
  *   Optional custom executor for record-layer asynchronous tasks (everything
  *   downstream of FDBDatabaseFactory). If None, the record layer creates and
- *   owns a dedicated executor: virtual-thread-per-task on JDK 21+, otherwise a
- *   named daemon cached thread pool. This replaces the JDK common pool default,
- *   which is easily starved by blocking work (e.g. Lucene index I/O). Default:
- *   None
+ *   owns a dedicated executor: virtual-thread-per-task on JDK 24+ (earlier JDKs
+ *   pin carriers when blocking inside synchronized sections, see JEP 491),
+ *   otherwise a named daemon cached thread pool. This replaces the JDK common
+ *   pool default, which is easily starved by blocking work (e.g. Lucene index
+ *   I/O). Default: None
  */
 case class FoundationDbConfig(
   minConnections: Int,

--- a/fdb-record-es-tests/src/main/scala/com/goodcover/fdb/record/SharedTestLayers.scala
+++ b/fdb-record-es-tests/src/main/scala/com/goodcover/fdb/record/SharedTestLayers.scala
@@ -23,11 +23,18 @@ object SharedTestLayers {
     } yield EventsourceConfig.makeDefaultConfig(directory)
   }
 
+  /**
+   * Deletes all records when the suite scope opens and again when it closes.
+   * The pre-clean matters because the keyspace path is deterministic per spec:
+   * a run that dies without running finalizers (CI timeout, kill -9) leaves
+   * data behind that would poison the next run.
+   */
   lazy val ClearAll: ZLayer[EventsourceLayer, Nothing, Any] = ZLayer.scoped {
     for {
       es <- ZIO.service[EventsourceLayer]
       _  <- Unsafe.unsafe { implicit unsafe =>
-              ZIO.addFinalizer(es.unsafeDeleteAllRecords.orDie)
+              es.unsafeDeleteAllRecords.orDie *>
+                ZIO.addFinalizer(es.unsafeDeleteAllRecords.orDie)
             }
     } yield ()
   }

--- a/fdb-record-es-tests/src/test/scala/com/goodcover/fdb/record/EventsourceLayerSpec.scala
+++ b/fdb-record-es-tests/src/test/scala/com/goodcover/fdb/record/EventsourceLayerSpec.scala
@@ -331,7 +331,7 @@ object EventsourceLayerSpec extends ZIOSpecDefault {
         lm.nonEmpty,
       )
     }
-  ) @@ TestAspect.withLiveClock)
+  ) @@ TestAspect.withLiveClock @@ TestAspect.timeout(2.minutes))
     .provideSome[FdbRecordDatabaseFactory](
       TestId.layer >+>
         (SharedTestLayers.ConfigLayer >>> EventsourceLayer.live) >+> SharedTestLayers.ClearAll

--- a/fdb-record-es-tests/src/test/scala/com/goodcover/fdb/record/InterruptSpec.scala
+++ b/fdb-record-es-tests/src/test/scala/com/goodcover/fdb/record/InterruptSpec.scala
@@ -23,7 +23,7 @@ object InterruptSpec extends ZIOSpecDefault {
       } yield assertTrue(true)
 
     }
-  ) @@ TestAspect.withLiveClock)
+  ) @@ TestAspect.withLiveClock @@ TestAspect.timeout(2.minutes))
     .provideSome[FdbRecordDatabaseFactory](
       TestId.layer >+>
         (SharedTestLayers.ConfigLayer >+> EventsourceLayer.live) >+> SharedTestLayers.ClearAll

--- a/fdb-record-es-tests/src/test/scala/com/goodcover/fdb/record/TagOrderingSpec.scala
+++ b/fdb-record-es-tests/src/test/scala/com/goodcover/fdb/record/TagOrderingSpec.scala
@@ -94,7 +94,7 @@ object TagOrderingSpec extends ZIOSpecDefault {
       )
 
     }
-  ) @@ TestAspect.withLiveClock)
+  ) @@ TestAspect.withLiveClock @@ TestAspect.timeout(2.minutes))
     .provideSome[FdbRecordDatabaseFactory](
       TestId.layer >+>
         (SharedTestLayers.ConfigLayer >+> EventsourceLayer.live) >+> SharedTestLayers.ClearAll

--- a/fdb-record-lucene-tests/src/main/protobuf/luceneTest.proto
+++ b/fdb-record-lucene-tests/src/main/protobuf/luceneTest.proto
@@ -24,6 +24,7 @@ message ComplexQuery {
   int32 coverageAmount = 3;
   repeated Interests interests = 4;
   repeated Entry metadata = 5;
+  string email = 6;
 }
 
 

--- a/fdb-record-lucene-tests/src/main/scala/com/goodcover/fdb/lucene/LuceneMetadata.scala
+++ b/fdb-record-lucene-tests/src/main/scala/com/goodcover/fdb/lucene/LuceneMetadata.scala
@@ -2,7 +2,12 @@ package com.goodcover.fdb.lucene
 
 import com.apple.foundationdb.record.RecordMetaData
 import com.apple.foundationdb.record.lucene.synonym.SynonymAnalyzer
-import com.apple.foundationdb.record.lucene.{ LuceneFunctionNames, LuceneIndexOptions, LuceneIndexTypes }
+import com.apple.foundationdb.record.lucene.{
+  EmailCjkSynonymAnalyzerFactory,
+  LuceneFunctionNames,
+  LuceneIndexOptions,
+  LuceneIndexTypes
+}
 import com.apple.foundationdb.record.metadata.Key.Expressions.*
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression.FanType
 import com.apple.foundationdb.record.metadata.{ Index, Key }
@@ -36,6 +41,7 @@ object LuceneMetadata {
         concat(
           function(LuceneFunctionNames.LUCENE_TEXT, field("text")),
           function(LuceneFunctionNames.LUCENE_SORTED, field("coverageAmount")),
+          function(LuceneFunctionNames.LUCENE_TEXT, field("email")),
           field("interests", FanType.FanOut).nest( //
             function(LuceneFunctionNames.LUCENE_TEXT, field("firstName")),
             function(LuceneFunctionNames.LUCENE_TEXT, field("lastName")),
@@ -51,6 +57,8 @@ object LuceneMetadata {
         ImmutableMap.of(
           LuceneIndexOptions.LUCENE_ANALYZER_NAME_OPTION,
           SynonymAnalyzer.QueryOnlySynonymAnalyzerFactory.ANALYZER_FACTORY_NAME,
+          LuceneIndexOptions.LUCENE_ANALYZER_NAME_PER_FIELD_OPTION,
+          s"email:${EmailCjkSynonymAnalyzerFactory.ANALYZER_FACTORY_NAME}",
           LuceneIndexOptions.OPTIMIZED_STORED_FIELDS_FORMAT_ENABLED,
           "true",
         )

--- a/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/FdbLuceneLayers.scala
+++ b/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/FdbLuceneLayers.scala
@@ -1,9 +1,7 @@
 package com.goodcover.fdb.lucene
 
 import com.apple.foundationdb.record.lucene.synonym.{ EnglishSynonymMapConfig, SynonymMapRegistryImpl }
-import com.goodcover.fdb.record.RecordDatabase.{ FdbMetadata, FdbRecordDatabase }
-import com.goodcover.fdb.record.{ BaseLayer, RecordConfig }
-import zio.{ Ref, ZIO, ZLayer }
+import zio.{ ZIO, ZLayer }
 
 object FdbLuceneLayers {
 
@@ -19,20 +17,4 @@ object FdbLuceneLayers {
     } yield ()
 
   }
-
-  class LuceneLayer(
-    override protected val recordDb: FdbRecordDatabase,
-    override protected val cfg: RecordConfig,
-    override protected val metaRef: Ref[Option[FdbMetadata]]
-  ) extends BaseLayer(recordDb, cfg, metaRef)
-
-  object LuceneLayer {
-    def apply(
-      recordDb: FdbRecordDatabase,
-      cfg: RecordConfig,
-      metaRef: Ref[Option[FdbMetadata]]
-    ): LuceneLayer =
-      new LuceneLayer(recordDb, cfg, metaRef)
-  }
-
 }

--- a/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/LuceneTest.scala
+++ b/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/LuceneTest.scala
@@ -390,12 +390,12 @@ object LuceneTest extends ZIOSpecDefault {
         Q.anyOf("a:1", "b:2") == "(a:1 OR b:2)",
       )
     }
-  ) @@ TestAspect.withLiveClock)
+  ) @@ TestAspect.withLiveClock @@ TestAspect.timeout(2.minutes))
     .provideSome[FdbRecordDatabaseFactory](
       TestId.layer >+>
         RecordTestLayers.configLayer(LuceneMetadata.build(), LuceneMetadata.descriptor) >+>
         RecordTestLayers.baseLayer >+>
-        RecordTestLayers.clearAllOnClose
+        RecordTestLayers.clearAll
     )
     .provideShared(
       FdbSpecLayers.sharedLayer ++ FdbLuceneLayers.suiteLayer >+> FdbRecordDatabaseFactory.live

--- a/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/LuceneTest.scala
+++ b/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/LuceneTest.scala
@@ -12,6 +12,7 @@ import com.goodcover.fdb.record.RecordDatabase.FdbRecordDatabaseFactory
 import com.goodcover.fdb.record.lucene.proto.LuceneTest.{ ComplexQuery, Interests }
 import com.goodcover.fdb.record.{ BaseLayer, RecordTestLayers }
 import org.apache.lucene.analysis.Analyzer
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute
 import org.apache.lucene.search.{ BooleanClause, BooleanQuery }
 import zio.*
 import zio.test.*
@@ -52,6 +53,18 @@ object LuceneTest extends ZIOSpecDefault {
   private def analyzers = {
     val standardAnalyzerSupplier = () => LuceneAnalyzerWrapper.getStandardAnalyzerWrapper.getAnalyzer
     standardAnalyzerSupplier
+  }
+
+  /** Collect the terms an analyzer produces for a field/text pair. */
+  private def analyze(analyzer: Analyzer, field: String, text: String): List[String] = {
+    val stream = analyzer.tokenStream(field, text)
+    val term   = stream.addAttribute(classOf[CharTermAttribute])
+    stream.reset()
+    val tokens = scala.collection.mutable.ListBuffer.empty[String]
+    while (stream.incrementToken()) tokens += term.toString
+    stream.end()
+    stream.close()
+    tokens.toList
   }
 
   private def searchQuery(
@@ -310,6 +323,61 @@ object LuceneTest extends ZIOSpecDefault {
         _ <- searchQuery("bill", assertSize = Some(2))
 
       } yield assertTrue(true)
+    },
+    test("email field uses the email-aware analyzer") {
+      for {
+        layer <- ZIO.service[BaseLayer]
+        _     <- layer.withStoreTxn { store =>
+                   for {
+                     _ <- store.saveRecord(
+                            ComplexQuery
+                              .newBuilder()
+                              .setId("1")
+                              .setText("Hello my name is dan! I really like going over to the well.")
+                              .setEmail("dan@goodcover.com")
+                              .setCoverageAmount(100)
+                              .build()
+                          )
+                     _ <- store.saveRecord(
+                            ComplexQuery
+                              .newBuilder()
+                              .setId("2")
+                              .setText("Hello my name is bill! I really like going over to the well.")
+                              .setEmail("bill@example.org")
+                              .setCoverageAmount(1_000)
+                              .build()
+                          )
+                   } yield ()
+                 }
+
+        // Both analyzers keep the address whole (the record layer's "STANDARD"
+        // wrapper is really UAX29URLEmailAnalyzer), so the exact address finds
+        // only its record either way...
+        exact <- searchQuery(LuceneSearch.LuceneQueryStrings.term("email", "dan@goodcover.com"))
+        // ...but only SYNONYM_EMAIL also generates word parts
+        // (WordDelimiterFilter with GENERATE_WORD_PARTS | PRESERVE_ORIGINAL),
+        // so a fragment like the local part matches through the override.
+        part  <- searchQuery("email:bill")
+
+        // Token-level proof that the per-field option routed the email field
+        // to the email-aware analyzer: it indexes the parts alongside the
+        // whole address, while the default analyzer indexes only the whole.
+        indexAnalyzer = registry
+                          .getLuceneAnalyzerCombinationProvider(
+                            LuceneMetadata.build().getIndex(INDEX),
+                            LuceneAnalyzerType.FULL_TEXT,
+                            java.util.Collections.emptyMap()
+                          )
+                          .provideIndexAnalyzer()
+                          .getAnalyzer
+        emailTokens   = analyze(indexAnalyzer, "email", "dan@goodcover.com")
+        textTokens    = analyze(indexAnalyzer, "text", "dan@goodcover.com")
+      } yield assertTrue(
+        exact.map(_.getId) == Chunk("1"),
+        part.map(_.getId) == Chunk("2"),
+        emailTokens.toSet == Set("dan@goodcover.com", "dan", "goodcover", "com"),
+        textTokens == List("dan@goodcover.com"),
+      )
     },
     test("query string helpers") {
       import LuceneSearch.LuceneQueryStrings as Q

--- a/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/LuceneTest.scala
+++ b/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/LuceneTest.scala
@@ -4,17 +4,15 @@ import com.apple.foundationdb.record.lucene.*
 import com.apple.foundationdb.record.lucene.highlight.{ HighlightedTerm, LuceneHighlighting }
 import com.apple.foundationdb.record.lucene.search.LuceneQueryParserFactoryProvider
 import com.apple.foundationdb.record.metadata.{ Index, IndexTypes }
-import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory
 import com.apple.foundationdb.record.provider.foundationdb.{ FDBQueriedRecord, IndexOrphanBehavior }
 import com.apple.foundationdb.record.query.RecordQuery
 import com.apple.foundationdb.record.query.expressions.{ Query, QueryComponent }
 import com.apple.foundationdb.record.query.plan.{ PlannableIndexTypes, ScanComparisons }
 import com.apple.foundationdb.record.{ EvaluationContext, ScanProperties }
 import com.goodcover.fdb.*
-import com.goodcover.fdb.lucene.FdbLuceneLayers.LuceneLayer
 import com.goodcover.fdb.record.RecordDatabase.{ FdbMetadata, FdbRecordDatabaseFactory, FdbRecordStore }
 import com.goodcover.fdb.record.lucene.proto.LuceneTest.{ ComplexQuery, Interests }
-import com.goodcover.fdb.record.{ RecordConfig, RecordKeySpace }
+import com.goodcover.fdb.record.{ BaseLayer, RecordTestLayers }
 import com.google.common.collect.Sets
 import org.apache.lucene.analysis.Analyzer
 import org.apache.lucene.search.{ BooleanClause, BooleanQuery }
@@ -70,8 +68,8 @@ object LuceneTest extends ZIOSpecDefault {
     text: String,
     additionalFilters: Option[QueryComponent] = None,
     assertSize: Option[Int] = None
-  )(implicit trace: Trace): ZIO[LuceneLayer, Throwable, Chunk[ComplexQuery]] =
-    ZIO.serviceWithZIO[LuceneLayer] { layer =>
+  )(implicit trace: Trace): ZIO[BaseLayer, Throwable, Chunk[ComplexQuery]] =
+    ZIO.serviceWithZIO[BaseLayer] { layer =>
       layer.withStoreTxn { store =>
         val qc = new LuceneQueryComponent(
           LuceneQueryType.QUERY,
@@ -127,7 +125,7 @@ object LuceneTest extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] = (suite("LuceneTest")(
     test("basic query with multiple params") {
       for {
-        layer <- ZIO.service[LuceneLayer]
+        layer <- ZIO.service[BaseLayer]
         _     <- layer.withStoreTxn { store =>
                    for {
                      _ <-
@@ -202,7 +200,7 @@ object LuceneTest extends ZIOSpecDefault {
     },
     test("highlight query with multiple params") {
       for {
-        layer <- ZIO.service[LuceneLayer]
+        layer <- ZIO.service[BaseLayer]
         _     <-
           layer.withStoreTxn { store =>
             for {
@@ -274,7 +272,7 @@ object LuceneTest extends ZIOSpecDefault {
     },
     test("highlight query different syntax") {
       for {
-        layer <- ZIO.service[LuceneLayer]
+        layer <- ZIO.service[BaseLayer]
         _     <-
           layer.withStoreTxn { store =>
             for {
@@ -347,7 +345,7 @@ object LuceneTest extends ZIOSpecDefault {
     test("use metadata queries") {
 
       for {
-        layer <- ZIO.service[LuceneLayer]
+        layer <- ZIO.service[BaseLayer]
         _     <-
           layer.withStoreTxn { store =>
             for {
@@ -389,51 +387,14 @@ object LuceneTest extends ZIOSpecDefault {
       } yield assertTrue(true)
     }
   ) @@ TestAspect.withLiveClock)
-    .provideSome[FdbRecordDatabaseFactory with FdbDatabase](
-      TestId.layer >+> ConfigLayer >+> FdbSpecLayers.suiteSubspaceLayer >+> TestKeySpace.live >+> ClearAll
+    .provideSome[FdbRecordDatabaseFactory](
+      TestId.layer >+>
+        RecordTestLayers.configLayer(LuceneMetadata.build(), LuceneMetadata.descriptor) >+>
+        RecordTestLayers.baseLayer >+>
+        RecordTestLayers.clearAllOnClose
     )
     .provideShared(
       FdbSpecLayers.sharedLayer ++ FdbLuceneLayers.suiteLayer >+> FdbRecordDatabaseFactory.live
     )
-
-  /**
-   * Clears all records from the LuceneLayer. This is a scoped layer that will
-   * delete all records when the layer is closed.
-   */
-  def ClearAll: ZLayer[FdbRecordDatabaseFactory with LuceneLayer, Nothing, Unit] =
-    ZLayer.scoped {
-      for {
-
-        ll <- ZIO.service[LuceneLayer]
-        _  <- ZIO.addFinalizer {
-                Unsafe.unsafe { implicit unsafe =>
-                  ll.unsafeDeleteAllRecords.orDie
-                }
-              }
-      } yield ()
-
-    }
-
-  def ConfigLayer(implicit fn: sourcecode.FullName): ZLayer[TestId with FdbRecordDatabaseFactory, Nothing, LuceneLayer] =
-    ZLayer.scoped {
-      for {
-        testKeySpace <- ZIO.service[TestId]
-        id            = testKeySpace.id
-        pathPerTest   = s"${fn.value}:$id:${com.goodcover.fdb.BuildInfo.scalaVersion}"
-        factory      <- ZIO.service[FdbRecordDatabaseFactory]
-        db           <- factory.db.orDie
-
-        directory = new KeySpaceDirectory(s"tests", KeySpaceDirectory.KeyType.STRING, pathPerTest)
-        _        <- ZIO.logDebug(s"provisioning the following path '$pathPerTest' in keyspaceDirectory '$directory''")
-        ks        = RecordKeySpace.makeDefaultConfig(directory)
-        rc        = new RecordConfig(
-                      ks,
-                      FdbMetadata(LuceneMetadata.build(), ks.tablePath),
-                      LuceneMetadata.descriptor,
-                      persistLocalMetadata = true
-                    )
-        ref      <- Ref.make(Option.empty[FdbMetadata])
-      } yield LuceneLayer(db, rc, ref)
-    }
 
 }

--- a/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/LuceneTest.scala
+++ b/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/LuceneTest.scala
@@ -1,19 +1,16 @@
 package com.goodcover.fdb.lucene
 
+import com.apple.foundationdb.record.ScanProperties
 import com.apple.foundationdb.record.lucene.*
 import com.apple.foundationdb.record.lucene.highlight.{ HighlightedTerm, LuceneHighlighting }
 import com.apple.foundationdb.record.lucene.search.LuceneQueryParserFactoryProvider
-import com.apple.foundationdb.record.metadata.{ Index, IndexTypes }
 import com.apple.foundationdb.record.provider.foundationdb.{ FDBQueriedRecord, IndexOrphanBehavior }
-import com.apple.foundationdb.record.query.RecordQuery
 import com.apple.foundationdb.record.query.expressions.{ Query, QueryComponent }
-import com.apple.foundationdb.record.query.plan.{ PlannableIndexTypes, ScanComparisons }
-import com.apple.foundationdb.record.{ EvaluationContext, ScanProperties }
 import com.goodcover.fdb.*
-import com.goodcover.fdb.record.RecordDatabase.{ FdbMetadata, FdbRecordDatabaseFactory, FdbRecordStore }
+import com.goodcover.fdb.lucene.LuceneSearch.*
+import com.goodcover.fdb.record.RecordDatabase.FdbRecordDatabaseFactory
 import com.goodcover.fdb.record.lucene.proto.LuceneTest.{ ComplexQuery, Interests }
 import com.goodcover.fdb.record.{ BaseLayer, RecordTestLayers }
-import com.google.common.collect.Sets
 import org.apache.lucene.analysis.Analyzer
 import org.apache.lucene.search.{ BooleanClause, BooleanQuery }
 import zio.*
@@ -25,13 +22,6 @@ import scala.jdk.CollectionConverters.*
 object LuceneTest extends ZIOSpecDefault {
 
   val INDEX = "ComplexQuery$text_index"
-
-  private val indexTypes = new PlannableIndexTypes(
-    Sets.newHashSet(IndexTypes.VALUE, IndexTypes.VERSION),
-    Sets.newHashSet(IndexTypes.RANK, IndexTypes.TIME_WINDOW_LEADERBOARD),
-    Sets.newHashSet(IndexTypes.TEXT),
-    Sets.newHashSet(LuceneIndexTypes.LUCENE)
-  )
 
   val registry = LuceneAnalyzerRegistryImpl.instance()
 
@@ -71,37 +61,8 @@ object LuceneTest extends ZIOSpecDefault {
   )(implicit trace: Trace): ZIO[BaseLayer, Throwable, Chunk[ComplexQuery]] =
     ZIO.serviceWithZIO[BaseLayer] { layer =>
       layer.withStoreTxn { store =>
-        val qc = new LuceneQueryComponent(
-          LuceneQueryType.QUERY,
-          text,
-          false,
-          Seq.empty.asJava,
-          true
-        )
-
-        val filter = additionalFilters match {
-          case Some(f) => Query.and(qc, f)
-          case None    => qc
-        }
-
-        val query = RecordQuery
-          .newBuilder()
-          .setRecordType("ComplexQuery")
-          .setFilter(filter)
-          .build()
-
         for {
-          planner <- ZIO.succeed(
-                       new LucenePlanner(
-                         store.metadata.metadata,
-                         store.storeState(),
-                         indexTypes,
-                         store.timer
-                       )
-                     )
-          plan    <- ZIO.succeed(planner.plan(query))
-          _       <- ZIO.collect(plan.getUsedIndexes.asScala.toList)(i => ZIO.logDebug(s"Used index: $i"))
-          results <- store.executeQuery(plan).runCollect
+          results <- store.luceneSearch("ComplexQuery", text, additionalFilter = additionalFilters).runCollect
           _       <- assertSize match {
                        case Some(v) => TestResult.liftTestResultToZIO(assertTrue(results.size == v))
                        case None    => ZIO.unit
@@ -109,18 +70,6 @@ object LuceneTest extends ZIOSpecDefault {
         } yield results.map(record => ComplexQuery.newBuilder().mergeFrom(record.record.getRecord).build())
       }
     }
-
-  def fullTextSearch(recordStore: FdbRecordStore, index: FdbMetadata => Index, search: String): LuceneScanBounds = {
-    val scan = new LuceneScanQueryParameters(
-      ScanComparisons.EMPTY,
-      new LuceneQueryMultiFieldSearchClause(LuceneQueryType.QUERY_HIGHLIGHT, search, false),
-      null,
-      null,
-      null,
-      new LuceneScanQueryParameters.LuceneQueryHighlightParameters(-1, 10)
-    )
-    scan.bind(recordStore.underlyingStore, index(recordStore.metadata), EvaluationContext.EMPTY)
-  }
 
   override def spec: Spec[TestEnvironment with Scope, Any] = (suite("LuceneTest")(
     test("basic query with multiple params") {
@@ -165,32 +114,10 @@ object LuceneTest extends ZIOSpecDefault {
                  }
 
         results <- layer.withStoreTxn { store =>
-                     val qc    =
-                       new LuceneQueryComponent(
-                         LuceneQueryType.QUERY,
-                         "text:(+hell* -dan) AND coverageAmount:[2000 TO 11000]",
-                         false,
-                         Seq.empty.asJava,
-                         true
-                       )
-                     val query = RecordQuery
-                       .newBuilder()
-                       .setRecordType("ComplexQuery")
-                       .setFilter(qc)
-                       .build()
-
-                     for {
-                       planner <- ZIO.succeed(
-                                    new LucenePlanner(
-                                      store.metadata.metadata,
-                                      store.storeState(),
-                                      indexTypes,
-                                      store.timer
-                                    )
-                                  )
-                       plan    <- ZIO.succeed(planner.plan(query))
-                       results <- store.executeQuery(plan).runCollect
-                     } yield results.map(record => ComplexQuery.newBuilder().mergeFrom(record.record.getRecord).build())
+                     store
+                       .luceneSearch("ComplexQuery", "text:(+hell* -dan) AND coverageAmount:[2000 TO 11000]")
+                       .runCollect
+                       .map(_.map(record => ComplexQuery.newBuilder().mergeFrom(record.record.getRecord).build()))
                    }
 
       } yield assertTrue( //
@@ -244,8 +171,7 @@ object LuceneTest extends ZIOSpecDefault {
 
               for {
                 sb      <- ZIO.succeed(
-                             fullTextSearch(
-                               store,
+                             store.luceneHighlightBounds(
                                _.getIndex(INDEX), // Nesting is with Underscores
                                "text:(+hell* -dan) AND coverageAmount:[2000 TO 11000] AND interests_firstName:Bill"
                              )
@@ -316,8 +242,7 @@ object LuceneTest extends ZIOSpecDefault {
 
               for {
                 sb      <- ZIO.succeed(
-                             fullTextSearch(
-                               store,
+                             store.luceneHighlightBounds(
                                _.getIndex(INDEX), // Nesting is with Underscores
                                "text:(+hell* -dan) AND coverageAmount:[* TO 200]"
                              )
@@ -385,6 +310,17 @@ object LuceneTest extends ZIOSpecDefault {
         _ <- searchQuery("bill", assertSize = Some(2))
 
       } yield assertTrue(true)
+    },
+    test("query string helpers") {
+      import LuceneSearch.LuceneQueryStrings as Q
+      assertTrue(
+        Q.term("text", "a+b") == "text:a\\+b",
+        Q.terms("key", List("a", "b")) == "key:(a OR b)",
+        Q.phrase("text", "say \"hi\"") == "text:\"say \\\"hi\\\"\"",
+        Q.prefix("text", "hel") == "text:hel*",
+        Q.allOf("a:1", "b:2") == "(a:1 AND b:2)",
+        Q.anyOf("a:1", "b:2") == "(a:1 OR b:2)",
+      )
     }
   ) @@ TestAspect.withLiveClock)
     .provideSome[FdbRecordDatabaseFactory](

--- a/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/RecordContextOptionsSpec.scala
+++ b/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/RecordContextOptionsSpec.scala
@@ -37,12 +37,12 @@ object RecordContextOptionsSpec extends ZIOSpecDefault {
         }
       }.map(executor => assertTrue(executor ne ForkJoinPool.commonPool()))
     },
-  ) @@ TestAspect.withLiveClock)
+  ) @@ TestAspect.withLiveClock @@ TestAspect.timeout(2.minutes))
     .provideSome[FdbRecordDatabaseFactory](
       TestId.layer >+>
         RecordTestLayers.configLayer(LuceneMetadata.build(), LuceneMetadata.descriptor) >+>
         RecordTestLayers.baseLayer >+>
-        RecordTestLayers.clearAllOnClose
+        RecordTestLayers.clearAll
     )
     .provideShared(
       FdbSpecLayers.sharedLayer >+> FdbRecordDatabaseFactory.live(options)

--- a/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/RecordContextOptionsSpec.scala
+++ b/fdb-record-lucene-tests/src/test/scala/com/goodcover/fdb/lucene/RecordContextOptionsSpec.scala
@@ -1,0 +1,50 @@
+package com.goodcover.fdb.lucene
+
+import com.apple.foundationdb.record.provider.foundationdb.properties.{ RecordLayerPropertyKey, RecordLayerPropertyStorage }
+import com.goodcover.fdb.record.RecordDatabase.{ FdbRecordDatabaseFactory, RecordContextOptions }
+import com.goodcover.fdb.record.{ BaseLayer, RecordTestLayers }
+import com.goodcover.fdb.{ FdbSpecLayers, TestId }
+import zio.*
+import zio.test.*
+
+import java.util.concurrent.ForkJoinPool
+
+/**
+ * Proves the database-level plumbing: a [[RecordContextOptions]] set on the
+ * factory reaches every transaction opened through `runAsync`, and record-layer
+ * async work runs on the owned executor instead of the JDK common pool.
+ */
+object RecordContextOptionsSpec extends ZIOSpecDefault {
+
+  private val testProp = RecordLayerPropertyKey.stringPropertyKey("goodcover_test_prop", "default")
+
+  private val options = RecordContextOptions.default.withProperties(
+    RecordLayerPropertyStorage.newBuilder().addProp(testProp, "configured").build()
+  )
+
+  override def spec: Spec[TestEnvironment with Scope, Any] = (suite("RecordContextOptionsSpec")(
+    test("database-level properties reach every transaction") {
+      ZIO.serviceWithZIO[BaseLayer] { layer =>
+        layer.withStoreTxn { store =>
+          ZIO.succeed(store.underlyingStore.getContext.getPropertyStorage.getPropertyValue(testProp))
+        }
+      }.map(value => assertTrue(value == "configured"))
+    },
+    test("record-layer async work does not run on the JDK common pool") {
+      ZIO.serviceWithZIO[BaseLayer] { layer =>
+        layer.withStoreTxn { store =>
+          ZIO.succeed(store.underlyingStore.getExecutor)
+        }
+      }.map(executor => assertTrue(executor ne ForkJoinPool.commonPool()))
+    },
+  ) @@ TestAspect.withLiveClock)
+    .provideSome[FdbRecordDatabaseFactory](
+      TestId.layer >+>
+        RecordTestLayers.configLayer(LuceneMetadata.build(), LuceneMetadata.descriptor) >+>
+        RecordTestLayers.baseLayer >+>
+        RecordTestLayers.clearAllOnClose
+    )
+    .provideShared(
+      FdbSpecLayers.sharedLayer >+> FdbRecordDatabaseFactory.live(options)
+    )
+}

--- a/fdb-record-lucene/src/main/scala/com/goodcover/fdb/lucene/LuceneSearch.scala
+++ b/fdb-record-lucene/src/main/scala/com/goodcover/fdb/lucene/LuceneSearch.scala
@@ -96,14 +96,14 @@ object LuceneSearch {
      * transaction.
      *
      * @param limit
-     *   maximum number of rows returned; 0 means unlimited.
+     *   maximum number of rows returned; Int.MaxValue means unlimited.
      * @param continuation
      *   resume from a previous [[Continuable]] continuation.
      */
     def luceneSearch(
       recordType: String,
       query: String,
-      limit: Int = 0,
+      limit: Int = Int.MaxValue,
       continuation: Array[Byte] = null,
       fields: Seq[String] = Nil,
       additionalFilter: Option[QueryComponent] = None,

--- a/fdb-record-lucene/src/main/scala/com/goodcover/fdb/lucene/LuceneSearch.scala
+++ b/fdb-record-lucene/src/main/scala/com/goodcover/fdb/lucene/LuceneSearch.scala
@@ -1,0 +1,175 @@
+package com.goodcover.fdb.lucene
+
+import com.apple.foundationdb.record.lucene.{
+  LuceneIndexTypes,
+  LucenePlanner,
+  LuceneQueryComponent,
+  LuceneQueryMultiFieldSearchClause,
+  LuceneQueryType,
+  LuceneScanBounds,
+  LuceneScanQueryParameters
+}
+import com.apple.foundationdb.record.metadata.{ Index, IndexTypes }
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord
+import com.apple.foundationdb.record.query.RecordQuery
+import com.apple.foundationdb.record.query.expressions.{ Query, QueryComponent }
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan
+import com.apple.foundationdb.record.query.plan.{ PlannableIndexTypes, ScanComparisons }
+import com.apple.foundationdb.record.{ EvaluationContext, ExecuteProperties, IsolationLevel }
+import com.goodcover.fdb.record.RecordDatabase.FdbRecordStore.Continuable
+import com.goodcover.fdb.record.RecordDatabase.{ FdbMetadata, FdbRecordStore }
+import com.google.common.collect.Sets
+import com.google.protobuf.Message
+import org.apache.lucene.queryparser.classic.QueryParserBase
+import zio.Trace
+import zio.stream.ZStream
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Lucene query support on top of [[FdbRecordStore]]: the planner/component
+ * packaging that every consumer otherwise hand-rolls, plus query-string
+ * builders. Import `LuceneSearch.*` for the store syntax.
+ *
+ * This is also the intended home for structured (non-string) query building.
+ */
+object LuceneSearch {
+
+  /** The plannable index types most stores want: standard types plus Lucene. */
+  val defaultIndexTypes: PlannableIndexTypes = new PlannableIndexTypes(
+    Sets.newHashSet(IndexTypes.VALUE, IndexTypes.VERSION),
+    Sets.newHashSet(IndexTypes.RANK, IndexTypes.TIME_WINDOW_LEADERBOARD),
+    Sets.newHashSet(IndexTypes.TEXT),
+    Sets.newHashSet(LuceneIndexTypes.LUCENE),
+  )
+
+  implicit final class LuceneRecordStoreOps(private val store: FdbRecordStore) extends AnyVal {
+
+    /**
+     * Plan a Lucene query against `recordType` with the [[LucenePlanner]],
+     * without executing it.
+     *
+     * @param fields
+     *   restrict the search to these fields; empty means multi-field search
+     *   across the index.
+     * @param additionalFilter
+     *   a non-Lucene [[QueryComponent]] AND-ed with the Lucene query.
+     */
+    def lucenePlan(
+      recordType: String,
+      query: String,
+      fields: Seq[String] = Nil,
+      additionalFilter: Option[QueryComponent] = None,
+      indexTypes: PlannableIndexTypes = defaultIndexTypes,
+    ): RecordQueryPlan = {
+      val component = new LuceneQueryComponent(
+        LuceneQueryType.QUERY,
+        query,
+        false,
+        fields.asJava,
+        fields.isEmpty,
+      )
+
+      val filter = additionalFilter match {
+        case Some(f) => Query.and(component, f)
+        case None    => component
+      }
+
+      val recordQuery = RecordQuery
+        .newBuilder()
+        .setRecordType(recordType)
+        .setFilter(filter)
+        .build()
+
+      val planner = new LucenePlanner(
+        store.metadata.metadata,
+        store.storeState(),
+        indexTypes,
+        store.timer,
+      )
+
+      planner.plan(recordQuery)
+    }
+
+    /**
+     * Plan and execute a Lucene query against `recordType` within the current
+     * transaction.
+     *
+     * @param limit
+     *   maximum number of rows returned; 0 means unlimited.
+     * @param continuation
+     *   resume from a previous [[Continuable]] continuation.
+     */
+    def luceneSearch(
+      recordType: String,
+      query: String,
+      limit: Int = 0,
+      continuation: Array[Byte] = null,
+      fields: Seq[String] = Nil,
+      additionalFilter: Option[QueryComponent] = None,
+      indexTypes: PlannableIndexTypes = defaultIndexTypes,
+    )(implicit trace: Trace): ZStream[Any, Throwable, Continuable[FDBQueriedRecord[Message]]] = {
+      val plan = lucenePlan(recordType, query, fields, additionalFilter, indexTypes)
+
+      val executeProperties = ExecuteProperties
+        .newBuilder()
+        .setIsolationLevel(IsolationLevel.SNAPSHOT)
+        .setReturnedRowLimit(limit)
+        .build()
+
+      store.executeQuery(plan, continuation, executeProperties, EvaluationContext.EMPTY)
+    }
+
+    /**
+     * Bind a multi-field full-text scan with highlighting against an index, for
+     * use with `scanIndex` + `fetchIndexRecords`.
+     */
+    def luceneHighlightBounds(
+      index: FdbMetadata => Index,
+      search: String,
+      snippetSize: Int = 10,
+    ): LuceneScanBounds = {
+      val scan = new LuceneScanQueryParameters(
+        ScanComparisons.EMPTY,
+        new LuceneQueryMultiFieldSearchClause(LuceneQueryType.QUERY_HIGHLIGHT, search, false),
+        null,
+        null,
+        null,
+        new LuceneScanQueryParameters.LuceneQueryHighlightParameters(-1, snippetSize),
+      )
+      scan.bind(store.underlyingStore, index(store.metadata), EvaluationContext.EMPTY)
+    }
+  }
+
+  /**
+   * Builders for Lucene query strings. These compose textually; combine with
+   * `AND`/`OR` or [[allOf]]/[[anyOf]].
+   */
+  object LuceneQueryStrings {
+
+    /** Escape all Lucene query syntax in `value`. */
+    def escape(value: String): String = QueryParserBase.escape(value)
+
+    /** `field:value` with the value escaped. */
+    def term(field: String, value: String): String = s"$field:${escape(value)}"
+
+    /** `field:(a OR b OR c)` with each value escaped. */
+    def terms(field: String, values: Iterable[String]): String =
+      values.map(escape).mkString(s"$field:(", " OR ", ")")
+
+    /** `field:"..."` with quote/backslash escaping suitable inside a phrase. */
+    def phrase(field: String, value: String): String = {
+      val escaped = value.replace("\\", "\\\\").replace("\"", "\\\"")
+      s"""$field:"$escaped""""
+    }
+
+    /** `field:value*` prefix search with the value escaped. */
+    def prefix(field: String, value: String): String = s"$field:${escape(value)}*"
+
+    /** `(a AND b AND c)` */
+    def allOf(clauses: String*): String = clauses.mkString("(", " AND ", ")")
+
+    /** `(a OR b OR c)` */
+    def anyOf(clauses: String*): String = clauses.mkString("(", " OR ", ")")
+  }
+}

--- a/fdb-record-tests/src/main/scala/com/goodcover/fdb/record/RecordTestLayers.scala
+++ b/fdb-record-tests/src/main/scala/com/goodcover/fdb/record/RecordTestLayers.scala
@@ -50,13 +50,23 @@ object RecordTestLayers {
     } yield base
   }
 
-  /** Deletes the store and its metadata when the suite scope closes. */
-  val clearAllOnClose: ZLayer[BaseLayer, Nothing, Unit] = ZLayer.scoped {
+  /**
+   * Deletes the store and its metadata when the suite scope opens and again
+   * when it closes. The pre-clean matters because the keyspace path is
+   * deterministic per spec: a run that dies without running finalizers (CI
+   * timeout, kill -9) leaves data behind that would poison the next run.
+   */
+  val clearAll: ZLayer[BaseLayer, Nothing, Unit] = ZLayer.scoped {
     for {
       base <- ZIO.service[BaseLayer]
       _    <- Unsafe.unsafe { implicit unsafe =>
-                ZIO.addFinalizer(base.unsafeDeleteAllRecords.orDie)
+                base.unsafeDeleteAllRecords.orDie *>
+                  ZIO.addFinalizer(base.unsafeDeleteAllRecords.orDie)
               }
     } yield ()
   }
+
+  /** Use [[clearAll]]: it also pre-cleans leftovers from killed runs. */
+  @deprecated("use clearAll, which also cleans up leftovers from killed runs", "0.5.3")
+  val clearAllOnClose: ZLayer[BaseLayer, Nothing, Unit] = clearAll
 }

--- a/fdb-record-tests/src/main/scala/com/goodcover/fdb/record/RecordTestLayers.scala
+++ b/fdb-record-tests/src/main/scala/com/goodcover/fdb/record/RecordTestLayers.scala
@@ -1,0 +1,60 @@
+package com.goodcover.fdb.record
+
+import com.apple.foundationdb.record.RecordMetaData
+import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory
+import com.goodcover.fdb.record.RecordDatabase.{ FdbMetadata, FdbRecordDatabaseFactory }
+import com.goodcover.fdb.{ BuildInfo, TestId }
+import com.google.protobuf.Descriptors.FileDescriptor
+import zio.{ Unsafe, ZIO, ZLayer }
+
+/**
+ * Suite-scoped layers for record-store tests: a unique keyspace per test
+ * (derived from the spec name, [[TestId]], Scala version and cross token), a
+ * [[BaseLayer]] on top of it, and cleanup on scope close.
+ */
+object RecordTestLayers {
+
+  /**
+   * A [[RecordConfig]] rooted at a keyspace unique to the calling spec, in the
+   * same shape as `SharedTestLayers.ConfigLayer` for the eventsource side.
+   */
+  def configLayer(
+    metadata: => RecordMetaData,
+    descriptor: FileDescriptor,
+    persistLocalMetadata: Boolean = true,
+  )(implicit fn: sourcecode.FullName): ZLayer[TestId, Nothing, RecordConfig] = ZLayer {
+    for {
+      testId         <- ZIO.service[TestId]
+      extraCrossToken = sys.props.get("cross-token").getOrElse("no-xtoken")
+      pathPerTest     = s"${fn.value}:${testId.id}:${BuildInfo.scalaVersion}:$extraCrossToken"
+      directory       = new KeySpaceDirectory("tests", KeySpaceDirectory.KeyType.STRING, pathPerTest)
+      _              <- ZIO.logDebug(s"provisioning the following path '$pathPerTest' in keyspaceDirectory '$directory'")
+      ks              = RecordKeySpace.makeDefaultConfig(directory)
+    } yield RecordConfig(
+      recordKeySpace = ks,
+      localMetadata = FdbMetadata(metadata, ks.tablePath),
+      localFileDescriptor = descriptor,
+      persistLocalMetadata = persistLocalMetadata,
+    )
+  }
+
+  /** A [[BaseLayer]] from a factory-provided database and a [[RecordConfig]]. */
+  val baseLayer: ZLayer[FdbRecordDatabaseFactory & RecordConfig, Nothing, BaseLayer] = ZLayer {
+    for {
+      factory  <- ZIO.service[FdbRecordDatabaseFactory]
+      cfg      <- ZIO.service[RecordConfig]
+      recordDb <- factory.db.orDie
+      base     <- BaseLayer.make(recordDb, cfg)
+    } yield base
+  }
+
+  /** Deletes the store and its metadata when the suite scope closes. */
+  val clearAllOnClose: ZLayer[BaseLayer, Nothing, Unit] = ZLayer.scoped {
+    for {
+      base <- ZIO.service[BaseLayer]
+      _    <- Unsafe.unsafe { implicit unsafe =>
+                ZIO.addFinalizer(base.unsafeDeleteAllRecords.orDie)
+              }
+    } yield ()
+  }
+}

--- a/fdb-record-tests/src/main/scala/com/goodcover/fdb/record/RecordTestLayers.scala
+++ b/fdb-record-tests/src/main/scala/com/goodcover/fdb/record/RecordTestLayers.scala
@@ -38,7 +38,9 @@ object RecordTestLayers {
     )
   }
 
-  /** A [[BaseLayer]] from a factory-provided database and a [[RecordConfig]]. */
+  /**
+   * A [[BaseLayer]] from a factory-provided database and a [[RecordConfig]].
+   */
   val baseLayer: ZLayer[FdbRecordDatabaseFactory & RecordConfig, Nothing, BaseLayer] = ZLayer {
     for {
       factory  <- ZIO.service[FdbRecordDatabaseFactory]

--- a/fdb-record/src/main/scala/com/goodcover/fdb/record/BaseLayer.scala
+++ b/fdb-record/src/main/scala/com/goodcover/fdb/record/BaseLayer.scala
@@ -12,13 +12,20 @@ class BaseLayer(
   protected val cfg: RecordConfig,
   protected val metaRef: Ref[Option[FdbMetadata]]
 ) {
-  protected def getMetaData(implicit trace: Trace): UIO[FdbMetadata] =
+
+  /**
+   * Resolve the metadata for this store: cached, else loaded from the meta
+   * keyspace, else the locally-built metadata. Whatever wins is cached so
+   * subsequent transactions skip the remote load.
+   */
+  def getMetaData(implicit trace: Trace): UIO[FdbMetadata] =
     for {
       result <-
         metaRef.get.some
           .orElse(loadMetadata.some)
           .orElseFail(cfg.localMetadata)
           .merge
+      _      <- metaRef.setAsync(Some(result))
     } yield result
 
   protected def loadMetadata(implicit trace: Trace): Task[Option[FdbMetadata]] =
@@ -130,5 +137,25 @@ class BaseLayer(
         _  <- ZIO.logInfo(s"Deleted metaStore ${cfg.metaPath}")
 
       } yield ()
+    }
+}
+
+object BaseLayer {
+
+  /**
+   * The `RecordConfig => store` primitive: builds the metadata cache and the
+   * layer around it, so consumers don't hand-roll the
+   * `mkStore`/`getMetaData`/`metaRef` dance.
+   */
+  def make(recordDb: FdbRecordDatabase, cfg: RecordConfig)(implicit trace: Trace): UIO[BaseLayer] =
+    Ref.make(Option.empty[FdbMetadata]).map(new BaseLayer(recordDb, cfg, _))
+
+  val layer: ZLayer[FdbRecordDatabase & RecordConfig, Nothing, BaseLayer] =
+    ZLayer {
+      for {
+        recordDb <- ZIO.service[FdbRecordDatabase]
+        cfg      <- ZIO.service[RecordConfig]
+        base     <- make(recordDb, cfg)
+      } yield base
     }
 }

--- a/fdb-record/src/main/scala/com/goodcover/fdb/record/RecordDatabase.scala
+++ b/fdb-record/src/main/scala/com/goodcover/fdb/record/RecordDatabase.scala
@@ -223,19 +223,25 @@ object RecordDatabase {
 
     /**
      * Executor for record-layer async tasks when none is configured:
-     * virtual-thread-per-task on JDK 21+ (reflectively, the library targets
+     * virtual-thread-per-task on JDK 24+ (reflectively, the library targets
      * Java 11), otherwise a named daemon cached thread pool.
      */
     private[record] def defaultRecordExecutor(): ExecutorService =
       virtualThreadExecutor().getOrElse(cachedThreadPool())
 
     private def virtualThreadExecutor(): Option[ExecutorService] =
-      try {
-        val method = classOf[Executors].getMethod("newVirtualThreadPerTaskExecutor")
-        Some(method.invoke(null).asInstanceOf[ExecutorService])
-      } catch {
-        case _: Exception => None
-      }
+      // Until JDK 24 (JEP 491) a virtual thread blocking inside a synchronized
+      // section pins its carrier; Lucene blocks on FDB I/O inside synchronized
+      // sections, which deadlocks small carrier pools (e.g. 4-core CI
+      // runners). Only use virtual threads where pinning is solved.
+      if (java.lang.Runtime.version().feature() < 24) None
+      else
+        try {
+          val method = classOf[Executors].getMethod("newVirtualThreadPerTaskExecutor")
+          Some(method.invoke(null).asInstanceOf[ExecutorService])
+        } catch {
+          case _: Exception => None
+        }
 
     private def cachedThreadPool(): ExecutorService = {
       val counter = new AtomicLong(0L)

--- a/fdb-record/src/main/scala/com/goodcover/fdb/record/RecordDatabase.scala
+++ b/fdb-record/src/main/scala/com/goodcover/fdb/record/RecordDatabase.scala
@@ -234,7 +234,7 @@ object RecordDatabase {
         val method = classOf[Executors].getMethod("newVirtualThreadPerTaskExecutor")
         Some(method.invoke(null).asInstanceOf[ExecutorService])
       } catch {
-        case _: NoSuchMethodException => None
+        case _: Exception => None
       }
 
     private def cachedThreadPool(): ExecutorService = {
@@ -387,12 +387,9 @@ object RecordDatabase {
                             cf.asInstanceOf[CompletableFuture[? <: A]]
 
                           }.asJava
-          result       <- ZIO.fromCompletableFuture[A] {
-                            // Mirrors FDBDatabase.runAsync, but with a context config so
-                            // database-level properties reach every transaction.
-                            val runner = db.newRunner(options.contextConfigBuilder)
-                            runner.runAsync[A](functionToRun).whenComplete((_, _) => runner.close())
-                          }
+          runner       <- ZIO.attempt(db.newRunner(options.contextConfigBuilder))
+          _            <- ZIO.addFinalizer(ZIO.succeed(runner.close()))
+          result       <- ZIO.fromCompletableFuture[A](runner.runAsync[A](functionToRun))
         } yield result
       }
 

--- a/fdb-record/src/main/scala/com/goodcover/fdb/record/RecordDatabase.scala
+++ b/fdb-record/src/main/scala/com/goodcover/fdb/record/RecordDatabase.scala
@@ -16,6 +16,7 @@ import com.apple.foundationdb.record.provider.foundationdb.{
   FDBMetaDataStore,
   FDBQueriedRecord,
   FDBRecordContext,
+  FDBRecordContextConfig,
   FDBRecordStore,
   FDBStoreTimer,
   FDBStoredRecord,
@@ -23,9 +24,11 @@ import com.apple.foundationdb.record.provider.foundationdb.{
   IndexScanBounds,
   OnlineIndexer
 }
+import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage
 import com.apple.foundationdb.record.query.{ ParameterRelationshipGraph, RecordQuery }
 import com.apple.foundationdb.record.query.expressions.QueryComponent
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan
+import com.apple.foundationdb.record.util.ServiceLoaderProvider
 import com.apple.foundationdb.subspace.Subspace
 import com.apple.foundationdb.tuple.{ ByteArrayUtil2, Tuple }
 import com.apple.foundationdb.*
@@ -40,7 +43,9 @@ import zio.*
 import zio.stream.ZStream
 
 import java.lang
-import java.util.concurrent.CompletableFuture
+import java.util.ServiceLoader
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.{ CompletableFuture, ExecutorService, Executors }
 import scala.jdk.CollectionConverters.*
 import scala.jdk.FunctionConverters.*
 
@@ -72,12 +77,74 @@ object RecordDatabase {
 
   }
 
+  /**
+   * Database-level defaults applied to every [[FDBRecordContext]] opened
+   * through [[FdbRecordDatabase.runAsync]] (and therefore everything layered
+   * on top: streams, [[BaseLayer.withStoreTxn]], etc).
+   *
+   * @param properties
+   *   record-layer properties (e.g. Lucene's `LUCENE_EXECUTOR_SERVICE`,
+   *   `LUCENE_OPEN_PARALLELISM`, analyzer options) made available to every
+   *   transaction without call-site churn.
+   * @param configure
+   *   escape hatch to customize the rest of [[FDBRecordContextConfig]]
+   *   (timers, priorities, transaction timeouts, ...). Applied after
+   *   `properties` is set.
+   */
+  final case class RecordContextOptions(
+    properties: RecordLayerPropertyStorage,
+    configure: FDBRecordContextConfig.Builder => FDBRecordContextConfig.Builder,
+  ) {
+    def withProperties(props: RecordLayerPropertyStorage): RecordContextOptions = copy(properties = props)
+
+    def withConfigure(fn: FDBRecordContextConfig.Builder => FDBRecordContextConfig.Builder): RecordContextOptions =
+      copy(configure = fn)
+
+    private[record] def contextConfigBuilder: FDBRecordContextConfig.Builder =
+      configure(FDBRecordContextConfig.newBuilder().setRecordContextProperties(properties))
+  }
+
+  object RecordContextOptions {
+    val default: RecordContextOptions =
+      RecordContextOptions(RecordLayerPropertyStorage.getEmptyInstance, identity)
+  }
+
   class FdbRecordDatabaseFactory(runtime: Runtime[Any], _pool: FdbPool, id: Ref[Long]) extends FDBDatabaseFactoryImpl {
     private implicit val unsafe: Unsafe = Unsafe.unsafe(u => u)
     private val scope: Scope.Closeable  = runtime.unsafe.run(Scope.make).getOrThrow()
 
+    FdbRecordDatabaseFactory.pinServiceLoader()
+
     setStoreStateCacheFactory(MetaDataVersionStampStoreStateCacheFactory.newInstance())
     setAPIVersion(APIVersion.fromVersionNumber(_pool.config.apiVersion))
+
+    /**
+     * The record layer defaults to `ForkJoinPool.commonPool()` for all async
+     * work, which is easily starved by blocking I/O (Lucene directories,
+     * synchronous index maintenance). Own the executor instead: use the one
+     * from [[com.goodcover.fdb.FoundationDbConfig.recordExecutor]] when given,
+     * otherwise create one we shut down with the factory.
+     */
+    private val ownedExecutor: Option[ExecutorService] = _pool.config.recordExecutor match {
+      case Some(executor) =>
+        setExecutor(executor)
+        None
+      case None           =>
+        val executor = FdbRecordDatabaseFactory.defaultRecordExecutor()
+        setExecutor(executor)
+        Some(executor)
+    }
+
+    @volatile private var defaultContextOptions: RecordContextOptions = RecordContextOptions.default
+
+    /**
+     * Set database-level defaults for every context opened through
+     * [[FdbRecordDatabase.runAsync]]. Databases obtained from [[db]] (before
+     * or after this call) observe the new value.
+     */
+    def setContextOptions(options: RecordContextOptions): Unit = defaultContextOptions = options
+
+    def contextOptions: RecordContextOptions = defaultContextOptions
 
     override def initFDB(): FDB = runtime.unsafe.run {
       ZIO.attemptBlocking(_pool.fdb)
@@ -110,6 +177,8 @@ object RecordDatabase {
         }
       }
         .getOrThrow()
+
+      ownedExecutor.foreach(_.shutdown())
     }
 
     override def getDatabase(cf1: String): RFDBDatabase =
@@ -119,12 +188,63 @@ object RecordDatabase {
       _                <- id.update(_ + 1)
       openTransactions <- Ref.make(Set.empty[Long])
       blocking         <- ZIO.attemptBlocking(getDatabase(_pool.config.clusterFile.orNull))
-    } yield new FdbRecordDatabase(blocking, id, openTransactions)
+    } yield new FdbRecordDatabase(blocking, id, openTransactions, () => defaultContextOptions)
 
     def pool: FdbPool = _pool
   }
 
   object FdbRecordDatabaseFactory {
+
+    /**
+     * Stable function instance handed to [[ServiceLoaderProvider.initialize]]:
+     * the record layer compares loaders by equality, so re-initializing with
+     * the same instance is a no-op while a different one throws.
+     */
+    private val libraryServiceLoader: java.util.function.Function[Class[?], java.lang.Iterable[?]] =
+      new java.util.function.Function[Class[?], java.lang.Iterable[?]] {
+        override def apply(clazz: Class[?]): java.lang.Iterable[?] =
+          ServiceLoader.load(clazz, classOf[FdbRecordDatabaseFactory].getClassLoader)
+      }
+
+    /**
+     * Pin record-layer SPI resolution (analyzer registries, planner
+     * extensions, ...) to this library's classloader instead of the context
+     * classloader. In sbt/mill test runners and other layered-classloader
+     * environments the context classloader frequently cannot see the
+     * record-layer's `META-INF/services` entries; in production both loaders
+     * are the same, so this is harmless. Best effort: if something already
+     * triggered SPI loading or installed its own loader, leave it be.
+     */
+    private[record] def pinServiceLoader(): Unit =
+      try ServiceLoaderProvider.initialize(libraryServiceLoader)
+      catch {
+        case _: IllegalStateException => ()
+      }
+
+    /**
+     * Executor for record-layer async tasks when none is configured:
+     * virtual-thread-per-task on JDK 21+ (reflectively, the library targets
+     * Java 11), otherwise a named daemon cached thread pool.
+     */
+    private[record] def defaultRecordExecutor(): ExecutorService =
+      virtualThreadExecutor().getOrElse(cachedThreadPool())
+
+    private def virtualThreadExecutor(): Option[ExecutorService] =
+      try {
+        val method = classOf[Executors].getMethod("newVirtualThreadPerTaskExecutor")
+        Some(method.invoke(null).asInstanceOf[ExecutorService])
+      } catch {
+        case _: NoSuchMethodException => None
+      }
+
+    private def cachedThreadPool(): ExecutorService = {
+      val counter = new AtomicLong(0L)
+      Executors.newCachedThreadPool { (r: Runnable) =>
+        val t = new Thread(r, s"fdb-record-async-${counter.getAndIncrement()}")
+        t.setDaemon(true)
+        t
+      }
+    }
 
     val live: ZLayer[FdbPool, Nothing, FdbRecordDatabaseFactory] = ZLayer.scoped {
       for {
@@ -135,9 +255,23 @@ object RecordDatabase {
         _       <- ZIO.addFinalizer(ZIO.attemptBlocking(factory.shutdown()).orDie)
       } yield factory
     }
+
+    /** As [[live]], but with database-level [[RecordContextOptions]] applied. */
+    def live(options: RecordContextOptions): ZLayer[FdbPool, Nothing, FdbRecordDatabaseFactory] =
+      ZLayer.scoped {
+        for {
+          factory <- live.build.map(_.get[FdbRecordDatabaseFactory])
+          _       <- ZIO.succeed(factory.setContextOptions(options))
+        } yield factory
+      }
   }
 
-  class FdbRecordDatabase(db: RFDBDatabase, private[record] val idRef: Ref[Long], openTransactions: Ref[Set[Long]]) {
+  class FdbRecordDatabase(
+    db: RFDBDatabase,
+    private[record] val idRef: Ref[Long],
+    openTransactions: Ref[Set[Long]],
+    defaultContextOptions: () => RecordContextOptions = () => RecordContextOptions.default,
+  ) {
 
     /**
      * We do a lot of stuff across boundaries, but take care to make it not
@@ -222,6 +356,12 @@ object RecordDatabase {
       runAsync[R, A](ZIO.serviceWithZIO[FdbRecordContext](fn))
 
     def runAsync[R, A](fn: => ZIO[FdbRecordContext & R, Throwable, A])(implicit trace: Trace): ZIO[R, Throwable, A] =
+      runAsync[R, A](defaultContextOptions())(fn)
+
+    /** As [[runAsync]], but with explicit per-call [[RecordContextOptions]]. */
+    def runAsync[R, A](options: RecordContextOptions)(
+      fn: => ZIO[FdbRecordContext & R, Throwable, A]
+    )(implicit trace: Trace): ZIO[R, Throwable, A] =
       ZIO.scoped[R] {
         for {
           runtime <- ZIO.runtime[R]
@@ -245,7 +385,12 @@ object RecordDatabase {
                             cf.asInstanceOf[CompletableFuture[? <: A]]
 
                           }.asJava
-          result       <- ZIO.fromCompletableFuture[A](db.runAsync[A](functionToRun))
+          result       <- ZIO.fromCompletableFuture[A] {
+                            // Mirrors FDBDatabase.runAsync, but with a context config so
+                            // database-level properties reach every transaction.
+                            val runner = db.newRunner(options.contextConfigBuilder)
+                            runner.runAsync[A](functionToRun).whenComplete((_, _) => runner.close())
+                          }
         } yield result
       }
 

--- a/fdb-record/src/main/scala/com/goodcover/fdb/record/RecordDatabase.scala
+++ b/fdb-record/src/main/scala/com/goodcover/fdb/record/RecordDatabase.scala
@@ -79,17 +79,17 @@ object RecordDatabase {
 
   /**
    * Database-level defaults applied to every [[FDBRecordContext]] opened
-   * through [[FdbRecordDatabase.runAsync]] (and therefore everything layered
-   * on top: streams, [[BaseLayer.withStoreTxn]], etc).
+   * through [[FdbRecordDatabase.runAsync]] (and therefore everything layered on
+   * top: streams, [[BaseLayer.withStoreTxn]], etc).
    *
    * @param properties
    *   record-layer properties (e.g. Lucene's `LUCENE_EXECUTOR_SERVICE`,
    *   `LUCENE_OPEN_PARALLELISM`, analyzer options) made available to every
    *   transaction without call-site churn.
    * @param configure
-   *   escape hatch to customize the rest of [[FDBRecordContextConfig]]
-   *   (timers, priorities, transaction timeouts, ...). Applied after
-   *   `properties` is set.
+   *   escape hatch to customize the rest of [[FDBRecordContextConfig]] (timers,
+   *   priorities, transaction timeouts, ...). Applied after `properties` is
+   *   set.
    */
   final case class RecordContextOptions(
     properties: RecordLayerPropertyStorage,
@@ -139,8 +139,8 @@ object RecordDatabase {
 
     /**
      * Set database-level defaults for every context opened through
-     * [[FdbRecordDatabase.runAsync]]. Databases obtained from [[db]] (before
-     * or after this call) observe the new value.
+     * [[FdbRecordDatabase.runAsync]]. Databases obtained from [[db]] (before or
+     * after this call) observe the new value.
      */
     def setContextOptions(options: RecordContextOptions): Unit = defaultContextOptions = options
 
@@ -207,13 +207,13 @@ object RecordDatabase {
       }
 
     /**
-     * Pin record-layer SPI resolution (analyzer registries, planner
-     * extensions, ...) to this library's classloader instead of the context
-     * classloader. In sbt/mill test runners and other layered-classloader
-     * environments the context classloader frequently cannot see the
-     * record-layer's `META-INF/services` entries; in production both loaders
-     * are the same, so this is harmless. Best effort: if something already
-     * triggered SPI loading or installed its own loader, leave it be.
+     * Pin record-layer SPI resolution (analyzer registries, planner extensions,
+     * ...) to this library's classloader instead of the context classloader. In
+     * sbt/mill test runners and other layered-classloader environments the
+     * context classloader frequently cannot see the record-layer's
+     * `META-INF/services` entries; in production both loaders are the same, so
+     * this is harmless. Best effort: if something already triggered SPI loading
+     * or installed its own loader, leave it be.
      */
     private[record] def pinServiceLoader(): Unit =
       try ServiceLoaderProvider.initialize(libraryServiceLoader)
@@ -256,7 +256,9 @@ object RecordDatabase {
       } yield factory
     }
 
-    /** As [[live]], but with database-level [[RecordContextOptions]] applied. */
+    /**
+     * As [[live]], but with database-level [[RecordContextOptions]] applied.
+     */
     def live(options: RecordContextOptions): ZLayer[FdbPool, Nothing, FdbRecordDatabaseFactory] =
       ZLayer.scoped {
         for {


### PR DESCRIPTION
## Summary

Works through the fdb-client wishlist that makes Lucene (and other record-layer) usage tenable without consumer-side workarounds. With these landed, a consumer search store reduces to proto + metadata + doc mapping.

### 1. Own the record-layer executor
- `FoundationDbConfig.recordExecutor: Option[Executor]` feeds `FDBDatabaseFactory.setExecutor`.
- When unset, the factory creates and owns one: virtual-thread-per-task on JDK 21+ (reflectively — the library targets Java 11), otherwise a named daemon cached pool (`fdb-record-async-N`). Shut down with the factory.
- Replaces the JDK common pool default, which is easily starved by blocking Lucene I/O.

### 2. Context properties through `runAsync`
- New `RecordContextOptions(properties: RecordLayerPropertyStorage, configure: FDBRecordContextConfig.Builder => Builder)`.
- `runAsync` now opens contexts via `FDBDatabase.newRunner(contextConfig)` (mirrors `FDBDatabase.runAsync` runner lifecycle, same retry semantics), so `LUCENE_EXECUTOR_SERVICE`, `LUCENE_OPEN_PARALLELISM`, analyzer options, etc. are settable once at the database level — `FdbRecordDatabaseFactory.live(options)` or `setContextOptions` — with a per-call `runAsync(options)(fn)` override. Streams and `withStoreTxn` inherit automatically.

### 3. Lucene query helper on `FdbRecordStore`
- `LuceneSearch` in `fdb-record-lucene`: `store.luceneSearch(recordType, query, limit, …)` packages `LucenePlanner` + `PlannableIndexTypes` + `LuceneQueryComponent` + row-limit `ExecuteProperties`; `lucenePlan` exposes the unexecuted plan; `luceneHighlightBounds` covers highlight scans.
- `LuceneQueryStrings` provides `escape`/`term`/`terms`/`phrase`/`prefix`/`allOf`/`anyOf`, and is the future home for structured query building.

### 4. Pin SPI resolution to the library classloader
- `ServiceLoaderProvider.initialize` at factory init with a stable function instance; no-op if something already initialized it. Fixes analyzer-registry resolution under sbt/mill layered classloaders; harmless in production.

### 5. Store-factory primitive + test harness
- `BaseLayer.make`/`BaseLayer.layer` build the `metaRef` internally (the `RecordConfig => withStore` primitive); `getMetaData` is public and caches the resolved metadata, matching downstream `FdbKvStoreFactory` semantics so it can extend `BaseLayer` directly.
- New `RecordTestLayers` in the previously-empty `fdb-record-tests`: unique keyspace per spec, `BaseLayer` from the factory, cleanup on scope close. `LuceneTest` migrated onto it (bespoke `LuceneLayer`/`ConfigLayer`/`ClearAll` deleted).

### Bonus: per-field email analyzer
- Demonstrates `LUCENE_ANALYZER_NAME_PER_FIELD_OPTION -> "email:SYNONYM_EMAIL"` with the shipped `EmailCjkSynonymAnalyzerFactory`. Test pins the semantics: the default "STANDARD" wrapper is really `UAX29URLEmailAnalyzer` (whole-address tokens), while `SYNONYM_EMAIL` additionally generates word parts so fragments like the local part match.

## Test plan
- `RecordContextOptionsSpec` proves database-level properties reach every transaction and async work runs off the common pool.
- All suites green on live FDB for both Scala 2.13.18 and 3.3.7: fdb-core-tests (7), fdb-record-es-tests (27), fdb-record-lucene-tests (8), fdb-record-es-pekko-tests (15). Spark module compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)